### PR TITLE
Fix --home flag not working

### DIFF
--- a/omadot
+++ b/omadot
@@ -9,7 +9,7 @@ EXCLUDE_LIST=()
 HOME_FLAG=false
 
 parse_args() {
-    local args=()
+    args=()
     for arg in "$@"; do
         if [[ "$arg" == --exclude=* ]]; then
             IFS=',' read -ra EXCLUDE_LIST <<< "${arg#*=}"
@@ -19,7 +19,6 @@ parse_args() {
             args+=("$arg")
         fi
     done
-    echo "${args[@]}"
 }
 
 is_excluded() {
@@ -229,7 +228,8 @@ put_package() {
 }
 
 # Main command handling
-ARGS=($(parse_args "$@"))
+parse_args "$@"
+ARGS=("${args[@]}")
 COMMAND="${ARGS[0]:-}"
 TARGET="${ARGS[1]:-}"
 


### PR DESCRIPTION
## Bug Description
The `--home` flag does not work - it always looks in `~/.config/` instead of `~/`.

## How to Reproduce
```bash
echo "test" > ~/.testfile
omadot get .testfile --home
```

**Expected:** Move `~/.testfile` to `~/.dotfiles/testfile/.testfile`  
**Actual:** Error: `Warning: /home/user/.config/.testfile does not exist, skipping...`

## Root Cause
Line 232 calls `parse_args()` in a subshell, so `HOME_FLAG=true` is lost when the subshell exits.

## Fix
1. Remove `local` from `args` variable (make it global)
2. Remove `echo` statement  
3. Call `parse_args` directly instead of in subshell